### PR TITLE
.coafile: Add commit message checking (BUGGED)

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -28,6 +28,11 @@ bears = PyUnusedCodeBear
 default_actions =
     PyUnusedCodeBear: ApplyPatchAction
 
+[commit]
+bears = GitCommitBear
+shortlog_trailing_period = false
+shortlog_regex = (^Merge [0-9a-f]+ into [0-9a-f]+|[^:]*: [A-Z].*)
+
 [autopep8]
 bears = PEP8Bear
 default_actions = PEP8Bear: ApplyPatchAction


### PR DESCRIPTION
When using coala to check the files before comitting,
check for proper formatting of the commit message

Closes https://github.com/coala/coala-html/issues/38

- [x] I have rebased properly. Please see this for a tutorial.
- [x] I have gone through the commit guidelines and I've followed them:
- [x] I have followed the guidelines for the commit shortlog.
- [x] I have followed the guidelines for the commit body.
- [x] I have included the issue URL.
- [x] I have used the Fixes keyword if the commit fixes a real bug and the Closes keyword if it adds a feature/enhancement. See more here.
- [x] I have run all the tests and they all pass. That includes that all CI (below) is green - if GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!
