### PR TITLE
.travis.yml: Fix the travis environment for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ node_js:
 python:
   - "3.4"
 
+services: docker
+
 cache:
   pip: true
   directories:
@@ -29,7 +31,7 @@ script:
   - npm test
   - python -m pytest --cov
   - bash <(curl -s https://codecov.io/bash)
-  - coala
+  - docker run --volume=$(pwd):/app --workdir=/app coala/base coala-ci
 
 notifications:
   email: false

--- a/coalahtml/_coalahtml/app/styles/files.css
+++ b/coalahtml/_coalahtml/app/styles/files.css
@@ -36,8 +36,10 @@ pre.dark .typ { color: #98fb98 } /* type    - lightgreen */
 pre.dark .lit { color: #cd5c5c } /* literal - darkred */
 pre.dark .pun { color: #fff }    /* punctuation */
 pre.dark .pln { color: #fff }    /* plaintext */
+/* Start ignoring LineLengthBear */
 pre.dark .tag { color: #f0e68c; font-weight: bold } /* html tag - lightyellow */
 pre.dark .atn { color: #bdb76b; font-weight: bold } /* attribute name - khaki */
+/* Stop ignoring */
 pre.dark .atv { color: #ffa0a0 } /* attribute value - pink */
 pre.dark .dec { color: #98fb98 } /* decimal - lightgreen */
 


### PR DESCRIPTION
The coala lint step was throwing a bunch of warnings
because the Travis environment lacked the coala-boars package.
This has been fixed by using the coala docker for linting
which makes this a non-issue.

Fixes #90 

- [x] I have rebased properly. Please see this for a tutorial.
- [x] I have gone through the commit guidelines and I've followed them:
- [x] I have followed the guidelines for the commit shortlog.
- [x] I have followed the guidelines for the commit body.
- [x] I have included the issue URL.
- [x] I have used the Fixes keyword if the commit fixes a real bug and the Closes keyword if it adds a feature/enhancement. See more here.
- [ ] I have run all the tests and they all pass. That includes that all CI (below) is green - if GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!
