### PR TITLE
files.css: Add coala ignore around long lines

### DIFF
--- a/coalahtml/_coalahtml/app/styles/files.css
+++ b/coalahtml/_coalahtml/app/styles/files.css
@@ -36,8 +36,10 @@ pre.dark .typ { color: #98fb98 } /* type    - lightgreen */
 pre.dark .lit { color: #cd5c5c } /* literal - darkred */
 pre.dark .pun { color: #fff }    /* punctuation */
 pre.dark .pln { color: #fff }    /* plaintext */
+/* Start ignoring LineLengthBear */
 pre.dark .tag { color: #f0e68c; font-weight: bold } /* html tag - lightyellow */
 pre.dark .atn { color: #bdb76b; font-weight: bold } /* attribute name - khaki */
+/* Stop ignoring */
 pre.dark .atv { color: #ffa0a0 } /* attribute value - pink */
 pre.dark .dec { color: #98fb98 } /* decimal - lightgreen */
 


### PR DESCRIPTION
Added the ignore to squash the unnessesary error
about the lines that are 1 char over limit.

Fixes https://github.com/coala/coala-html/issues/91

- [x] I have rebased properly. Please see this for a tutorial.
- [x] I have gone through the commit guidelines and I've followed them:
- [x] I have followed the guidelines for the commit shortlog.
- [x] I have followed the guidelines for the commit body.
- [x] I have included the issue URL.
- [x] I have used the Fixes keyword if the commit fixes a real bug and the Closes keyword if it adds a feature/enhancement. See more here.
- [x] I have run all the tests and they all pass. That includes that all CI (below) is green - if GitMate issues appear you will have to amend your commits, pushing new commits on top is not sufficient!