### PR TITLE
.coafile: Add commit message checking

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -28,6 +28,11 @@ bears = PyUnusedCodeBear
 default_actions =
     PyUnusedCodeBear: ApplyPatchAction
 
+[commit]
+bears = GitCommitBear
+shortlog_trailing_period = false
+shortlog_regex = ([^:]*|[^:]+: [A-Z].*)
+
 [autopep8]
 bears = PEP8Bear
 default_actions = PEP8Bear: ApplyPatchAction


### PR DESCRIPTION
Note this is the proper pull request which should not have the merge bug. (coala/coala-bears#1037)
See #88 for original solution and the bug that happened with Github
This should have truly fixed it.

When pushing to the coaal-html repository,
check the commit message formatting to make
sure it conforms to coala project standards.

Fixes #38