### PR TITLE
Use codecov-python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ install:
 script:
   - npm test
   - python -m pytest --cov
-  - bash <(curl -s https://codecov.io/bash)
+  - codecov
   - docker run --volume=$(pwd):/app --workdir=/app coala/base coala-ci
 
 notifications:

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage==4.0.3
+codecov~=2.0.9
 pytest==2.8.7
 pytest-cov==2.2.1
 pytest-env==0.6.0


### PR DESCRIPTION
Currently codecov-bash is used, which involves an uncached fetch
of a unversioned bash script.
Using codecov-python allows the tool to be cached, and greater
reliability due to versioned releases of the tool.

In addition, codecov-bash does not work on Windows, and our
developer base is better tuned to investigate any python
related problems.

Fixes https://github.com/coala/coala-html/issues/117